### PR TITLE
Tiny fix to .travis.yml to avoid grid builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ script: ./travis-tool.sh run_tests
 after_failure:
 - ./travis-tool.sh dump_logs
 env:
-- NOT_CRAN="true"
-- WARNINGS_ARE_ERRORS=1
+- NOT_CRAN="true" WARNINGS_ARE_ERRORS=1
 notifications:
   email:
     on_success: change


### PR DESCRIPTION
This is a small thing but on Travis-CI you want all your env variables on one line.  Multiple lines means
multiple build environments.